### PR TITLE
Allow minidump_dump to print module lists that would normally be reje…

### DIFF
--- a/src/processor/minidump_dump.cc
+++ b/src/processor/minidump_dump.cc
@@ -121,6 +121,9 @@ static bool PrintMinidumpDump(const Options& options) {
     thread_list->Print();
   }
 
+  // It's useful to be able to see the full list of modules here even if it
+  // would cause minidump_stackwalk to fail.
+  MinidumpModuleList::set_max_modules(UINT32_MAX);
   MinidumpModuleList *module_list = minidump.GetModuleList();
   if (!module_list) {
     ++errors;


### PR DESCRIPTION
…cted

for being too long.

We've seen some minidumps that fail to process because they contain
a ridiculous number of modules (usually due to something leaking shm
mappings, it looks like). They're annoying to investigate because even
minidump_dump fails to load and print the module list. This patch makes
minidump_dump effectively remove the limit on the number of modules it
will load, so inspecting the dump by hand is possible.

R=vapier@chromium.org

Change-Id: I7a55387ca4aaad8664cd4d2651052da989366027
Reviewed-on: https://chromium-review.googlesource.com/957130
Reviewed-by: Mike Frysinger <vapier@chromium.org>